### PR TITLE
Port audio

### DIFF
--- a/libsndfile_1.0.28.py
+++ b/libsndfile_1.0.28.py
@@ -1,0 +1,90 @@
+from distutils.spawn import find_executable
+from conans import ConanFile, CMake, tools
+import os, stat, shutil
+
+def on_shutil_rmtree_error( func, path, exc_info ):
+    os.chmod( path, stat.S_IWRITE )
+    os.remove( path )
+
+def remove_directory( directory_path ):
+    shutil.rmtree( directory_path, onerror = on_shutil_rmtree_error )
+
+def remove( path ):
+    if os.path.exists( path ):
+        if os.path.isdir( path ):
+            remove_directory( path )
+        else:
+            os.remove( path )
+
+
+class LibSndFile( ConanFile ):
+    name = "libsndfile"
+    license = " "
+    description = "C library for reading and writing files containing samples audio data"
+    url = "http://www.mega-nerd.com/libsndfile/"
+    generators = "virtualrunenv"
+
+    version = "1.0.29"
+    settings = "os", "build_type"
+    options = { "shared": [ True, False ] }
+    default_options = { "shared": True }
+
+    build_requires = ( ( "cmake/3.11.2@tdelame/stable" ), ( "ninja/1.8.2@tdelame/stable" ) )
+
+    def source( self ):
+        sha = "1a87c443fe37bd67c8d1e2d2b4c8b0291806eb90"
+        download_url = "https://github.com/erikd/libsndfile/archive/{}.zip".format( sha )
+        folder_name = "libsndfile-{}".format( sha )
+        zipped_folder_name = "{}.zip".format( folder_name )
+
+        tools.download( download_url, zipped_folder_name )
+        tools.unzip( zipped_folder_name )
+        shutil.move( folder_name, self.name )
+        os.remove( zipped_folder_name )
+
+    def configure_cmake( self ):
+        #Note: I do not add ogg, flac, and vorbis dependences here since we do
+        # not have requests nor requirements for these formats.
+        definition_dict = {
+            "CMAKE_BUILD_TYPE": "RELEASE" if self.settings.build_type == "Release" else "DEBUG",
+            
+            "ENABLE_COMPATIBLE_LIBSNDFILE_NAME": True,
+            "BUILD_SHARED_LIBS": self.options.shared,
+            "ENABLE_PACKAGE_CONFIG": False,
+            "ENABLE_BOW_DOCS": False,
+            "BUILD_PROGRAMS": False,
+            "BUILD_EXAMPLES": False,
+            "BUILD_TESTING": False,
+            "BUILD_REGTEST": False,
+        }
+
+        if self.settings.os == "Linux":
+
+            if self.settings.build_type == "Release":
+                definition_dict[ "CMAKE_C_FLAGS" ] = "-fPIC -m64 -O3"
+            else:
+                definition_dict[ "CMAKE_C_FLAGS" ] = "-fPIC -m64 -Og -g"
+
+            if find_executable( "ldd" ) is not None:
+                definition_dict[ "CMAKE_SHARED_LINKER_FLAGS" ] = "-fuse-ld=lld"
+                definition_dict[ "CMAKE_EXE_LINKER_FLAGS"    ] = "-fuse-ld=lld"
+
+        cmake = CMake( self, generator = "Ninja" )
+        cmake.configure( defs = definition_dict, source_folder = self.name )
+        return cmake
+
+    def build( self ):
+        cmake = self.configure_cmake()
+        cmake.build()
+
+
+    def package( self ):
+        cmake = self.configure_cmake()
+        cmake.install()
+        remove( "{}/share".format( self.package_folder ) )
+        remove( "{}/lib/pkgconfig".format( self.package_folder ) )
+
+    def package_info( self ):
+        self.env_info.LD_LIBRARY_PATH.append(os.path.join(self.package_folder, "lib"))
+        self.cpp_info.libs = tools.collect_libs(self)  
+

--- a/portaudio_2018-12-24.py
+++ b/portaudio_2018-12-24.py
@@ -1,0 +1,86 @@
+from distutils.spawn import find_executable
+from conans import ConanFile, CMake, tools
+import os
+
+
+class PortAudio( ConanFile ):
+    name = "PortAudio"
+    license = " "
+    description = "Free, cross-platform, open-source, audio I/O library"
+    url = "www.portaudio.com"
+    generators = "virtualrunenv"
+
+    version = "2018-12-24"
+    settings = "os", "build_type"
+    options = { "shared": [ True, False ] }
+    default_options = { "shared": True }
+
+    build_requires = ( ( "cmake/3.11.2@tdelame/stable" ), ( "ninja/1.8.2@tdelame/stable" ) )
+
+    def build_requirements( self ):
+        if self.settings.os == "Linux":
+            self.build_requires( "alsa-lib/1.0.29@tdelame/stable" )
+
+    def source( self ):
+        download_url = "https://app.assembla.com/spaces/portaudio/git/source/b7870b08f770c1e84b754e662c08b6942ff7d021?_format=zip&format=html"
+        zipped_folder_name = "root.zip"
+
+        tools.download( download_url, zipped_folder_name )
+        tools.unzip( zipped_folder_name, self.name )
+        os.remove( zipped_folder_name )
+
+    def build( self ):
+        definition_dict = {
+            "CMAKE_BUILD_TYPE": self.settings.build_type,
+            "PA_BUILD_SHARED": self.options.shared,
+            "PA_BUILD_STATIC": not self.options.shared,
+            "PA_ENABLE_DEBUG_OUTPUT": self.settings.build_type != "Release",
+            "PA_LIBNAME_ADD_SUFFIX": self.settings.os == "Windows",
+            "PA_BUILD_EXAMPLES": False,
+            "PA_BUILD_TESTS": False,
+        }
+
+        if self.settings.os == "Linux":
+            alsa_info = self.deps_cpp_info[ "alsa-lib" ]
+            definition_dict[ "ALSA_INCLUDE_DIR" ] = alsa_info.include_paths[ 0 ]
+            definition_dict[ "ALSA_LIBRARY" ] = os.path.join( alsa_info.lib_paths[ 0 ], "libasound.so" )
+            definition_dict[ "PA_USE_ALSA" ] = True
+            definition_dict[ "PA_USE_JACK" ] = False
+
+            if find_executable( "lld" ) is not None:
+                definition_dict[ "CMAKE_SHARED_LINKER_FLAGS" ] = "-fuse-ld=lld"
+                definition_dict[ "CMAKE_EXE_LINKER_FLAGS"    ] = "-fuse-ld=lld"
+
+        elif self.settings.os == "Windows":
+            definition_dict[ "PA_USE_MME" ] = True
+
+            definition_dict[ "PA_USE_WDMKS_DEVICE_INFO" ] = False
+            definition_dict[ "PA_UNICODE_BUILD" ] = False
+            definition_dict[ "PA_USE_WASAPI" ] = False
+            definition_dict[ "PA_USE_WDMKS" ] = False
+            definition_dict[ "PA_USE_ASIO" ] = False
+            definition_dict[ "PA_USE_DS" ] = False
+
+
+        cmake = CMake( self, generator = "Ninja" )
+        cmake.configure(
+            defs = definition_dict,
+            source_folder = self.name
+        )
+        cmake.build()
+
+
+    def package( self ):
+        if self.settings.os == "Linux":
+            libpattern = "*.so*" if self.options.shared else "*.a"
+            self.copy( "portaudio.h", src = "PortAudio/include", dst = "include" )
+            self.copy( "pa_linux_alsa.h", src = "PortAudio/include", dst = "include" )
+            self.copy( libpattern, dst ="lib" )
+        elif self.settings.os == "Windows":
+            self.copy( "portaudio.h", src = "PortAudio/include", dst = "include" )
+            self.copy( "pa_win_mme.h", src = "PortAudio/include", dst = "include" )
+            #libs?
+
+    def package_info(self):
+        self.env_info.LD_LIBRARY_PATH.append(os.path.join(self.package_folder, "lib"))
+        self.cpp_info.libs = tools.collect_libs(self)


### PR DESCRIPTION
Ajout de deux librairies pour gérer le son dans Rumba de manière portable : 
* libsnfile, pour ouvrir des fichiers audio et en extraire les samples
* PortAudio, pour interagir de manière portable avec les cartes sons.

Les règles seront peut-être à mettre à jour pour Windows. 